### PR TITLE
Fix async ping

### DIFF
--- a/src/EthernetICMP.h
+++ b/src/EthernetICMP.h
@@ -303,6 +303,7 @@ private:
     static uint16_t ping_timeout;
 
     void openSocket();
+    void closeSocket();
 
     Status sendEchoRequest(const IPAddress& addr, const EthernetICMPEcho& echoReq);
     void receiveEchoReply(const EthernetICMPEcho& echoReq, const IPAddress& addr, EthernetICMPEchoReply& echoReply);


### PR DESCRIPTION
From the W5500 IPRAW documentation (http://www.wizwiki.net/wiki/lib/exe/fetch.php/products:w5500:w5500_ap_ipraw_v100e.pdf):
'After initialization of W5500, the Ping Reply is processed automatically. However, be aware that the Hardwired Ping Reply Logic is disabled if ICMP is opened as SOCKET n in IPRAW mode.'